### PR TITLE
change user_data from string to list

### DIFF
--- a/blue-green/variables.tf
+++ b/blue-green/variables.tf
@@ -40,7 +40,8 @@ variable "associate_public_ip_address" {
 }
 variable "user_data" {
   description = "(Optional) The user data to provide when launching the instance"
-  default = ""
+  default = [""]
+  type    = "list"
 }
 variable "disk_volume_size" {
   description = "(Optional) The size of the volume in gigabytes"


### PR DESCRIPTION
fix: * module.app_admin_deploy.var.user_data: variable user_data in module app_admin_deploy should be type string, got list
when using template_cloudinit_config