### PR TITLE
[WIP] Created a deployer-role module

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ module "cpu-scaling" {
 }
 ```
 
+## deployer-role
+
+Terraform module that creates an IAM policy that allows to manage a blue-green deployment. It also creates an IAM role with that policy attached.
+
+### Variables
+
+See the [deployer-role/variables.tf](deployer-role/variables.tf) file.
+
+### Outputs
+
+* `iam_role_arn`: (String) Created IAM role ARN
+* `iam_role_name`: (String) Created IAM role name
+* `iam_policy_arn`: (String) Created IAM policy ARN
+* `iam_policy_name`: (String) Created IAM policy name
+* `iam_policy_id`: (String) Created IAM policy ID
+
 ## Blue-green deployments
 The blue-green deployment script expects certain inputs and outputs in the Terraform project you want to deploy in a blue-green fashion.
 ### Required outputs:

--- a/deployer-role/main.tf
+++ b/deployer-role/main.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "deployer_role" {
   name               = "deployer_${var.project}_${var.environment}"
-  path               = "/bluegreen"
+  path               = "/bluegreen/"
   assume_role_policy = "${data.aws_iam_policy_document.deployer_assume_role_policy.json}"
 }
 
@@ -19,7 +19,6 @@ data "aws_iam_policy_document" "deployer_assume_role_policy" {
 
 resource "aws_iam_role_policy" "deployer_policy" {
   name_prefix = "deployer_${var.project}_${var.environment}_"
-  description = "Policy to allow blue-green deployments in this account"
   role        = "${aws_iam_role.deployer_role.id}"
 
   policy = <<EOF
@@ -28,10 +27,10 @@ resource "aws_iam_role_policy" "deployer_policy" {
   "Statement": [
     {
       "Action": [
-        "TBD"
+        "*"
       ],
       "Effect": "Allow",
-      "Resource": "TBD"
+      "Resource": "*"
     }
   ]
 }

--- a/deployer-role/main.tf
+++ b/deployer-role/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "deployer_role" {
-  name_prefix        = "deployer_${var.project}_${var.environment}_"
+  name               = "deployer_${var.project}_${var.environment}"
   path               = "/bluegreen"
   assume_role_policy = "${data.aws_iam_policy_document.deployer_assume_role_policy.json}"
 }

--- a/deployer-role/main.tf
+++ b/deployer-role/main.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_role" "deployer_role" {
+  name_prefix        = "deployer_${var.project}_${var.environment}_"
+  path               = "/bluegreen"
+  assume_role_policy = "${data.aws_iam_policy_document.deployer_assume_role_policy.json}"
+}
+
+data "aws_iam_policy_document" "deployer_assume_role_policy" {
+  statement {
+    sid     = "1"
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.principals_aws}"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "deployer_policy" {
+  name_prefix = "deployer_${var.project}_${var.environment}_"
+  description = "Policy to allow blue-green deployments in this account"
+  role        = "${aws_iam_role.deployer_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "TBD"
+      ],
+      "Effect": "Allow",
+      "Resource": "TBD"
+    }
+  ]
+}
+EOF
+}

--- a/deployer-role/outputs.tf
+++ b/deployer-role/outputs.tf
@@ -1,0 +1,19 @@
+output "iam_role_arn" {
+  value = "${aws_iam_role.deployer_role.arn}"
+}
+
+output "iam_role_name" {
+  value = "${aws_iam_role.deployer_role.name}"
+}
+
+output "iam_policy_arn" {
+  value = "${aws_iam_policy.deployer_policy.arn}"
+}
+
+output "iam_policy_name" {
+  value = "${aws_iam_policy.deployer_policy.name}"
+}
+
+output "iam_policy_id" {
+  value = "${aws_iam_policy.deployer_policy.id}"
+}

--- a/deployer-role/outputs.tf
+++ b/deployer-role/outputs.tf
@@ -7,13 +7,13 @@ output "iam_role_name" {
 }
 
 output "iam_policy_arn" {
-  value = "${aws_iam_policy.deployer_policy.arn}"
+  value = "${aws_iam_role_policy.deployer_policy.arn}"
 }
 
 output "iam_policy_name" {
-  value = "${aws_iam_policy.deployer_policy.name}"
+  value = "${aws_iam_role_policy.deployer_policy.name}"
 }
 
 output "iam_policy_id" {
-  value = "${aws_iam_policy.deployer_policy.id}"
+  value = "${aws_iam_role_policy.deployer_policy.id}"
 }

--- a/deployer-role/variables.tf
+++ b/deployer-role/variables.tf
@@ -1,0 +1,12 @@
+variable "environment" {
+  description = "Environment to deploy on"
+}
+
+variable "project" {
+  description = "Project name to use"
+}
+
+variable "principals_aws" {
+  description = "List of ARNs of the IAM users or roles that can assume this role. Should be something like this: arn:aws:iam::AWS-account-ID:role/my_role"
+  default     = []
+}


### PR DESCRIPTION
This is needed to automate the blue-green deployments, in order to give the CI workers the needed permissions to deploy.

Policy still TBD