### PR TITLE
Change from maps to tfvars

### DIFF
--- a/bluegreen.py
+++ b/bluegreen.py
@@ -267,7 +267,7 @@ def buildTerraformVars (blueMax, blueMin, blueDesired, blueAMI, greenMax, greenM
     for key, value in variables.iteritems():
         out.append('-var \'%s=%s\'' % (key, value))
 
-    # When using terraform environmenst, set the environment tfvar file
+    # When using terraform environments, set the environment tfvars file
     if environment != None:
         out.append('-var-file=%s.tfvars' % (environment))
     return ' '.join(out)

--- a/bluegreen.py
+++ b/bluegreen.py
@@ -264,12 +264,13 @@ def buildTerraformVars (blueMax, blueMin, blueDesired, blueAMI, greenMax, greenM
     }
     out = []
 
-    for key, value in variables.iteritems():
-        out.append('-var \'%s=%s\'' % (key, value))
-
     # When using terraform environments, set the environment tfvars file
     if environment != None:
         out.append('-var-file=%s.tfvars' % (environment))
+
+    for key, value in variables.iteritems():
+        out.append('-var \'%s=%s\'' % (key, value))
+
     return ' '.join(out)
 
 if __name__ == "__main__":

--- a/bluegreen.py
+++ b/bluegreen.py
@@ -263,12 +263,13 @@ def buildTerraformVars (blueMax, blueMin, blueDesired, blueAMI, greenMax, greenM
         'green_ami': greenAMI
     }
     out = []
+
+    for key, value in variables.iteritems():
+        out.append('-var \'%s=%s\'' % (key, value))
+
+    # When using terraform environmenst, set the environment tfvar file
     if environment != None:
-        for key, value in variables.iteritems():
-            out.append('-var \'%s={ %s = "%s" }\'' % (key, environment, value))
-    else:
-        for key, value in variables.iteritems():
-            out.append('-var \'%s=%s\'' % (key, value))
+        out.append('-var-file=%s.tfvars' % (environment))
     return ' '.join(out)
 
 if __name__ == "__main__":

--- a/bluegreen.py
+++ b/bluegreen.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 
 def main(argv):
-    helptext = 'bluegreen.py -f <path to terraform project> -a <ami> -c <command> -t <timeout>'
+    helptext = 'bluegreen.py -f <path to terraform project> -a <ami> -c <command> -t <timeout> -e <envirment.tfvars path>'
 
     try:
         opts, args = getopt.getopt(argv,"hf:a:c:t:e:",["folder=","ami=","command=", "timeout=", "environment="])
@@ -266,7 +266,7 @@ def buildTerraformVars (blueMax, blueMin, blueDesired, blueAMI, greenMax, greenM
 
     # When using terraform environments, set the environment tfvars file
     if environment != None:
-        out.append('-var-file=%s.tfvars' % (environment))
+        out.append('-var-file=%s' % (environment))
 
     for key, value in variables.iteritems():
         out.append('-var \'%s=%s\'' % (key, value))

--- a/bluegreen.py
+++ b/bluegreen.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 
 def main(argv):
-    helptext = 'bluegreen.py -f <path to terraform project> -a <ami> -c <command> -t <timeout> -e <envirment.tfvars path>'
+    helptext = 'bluegreen.py -f <path to terraform project> -a <ami> -c <command> -t <timeout> -e <environment.tfvars path>'
 
     try:
         opts, args = getopt.getopt(argv,"hf:a:c:t:e:",["folder=","ami=","command=", "timeout=", "environment="])


### PR DESCRIPTION
We had an meeting where we discussed the usage of using variable maps versus tfvars files to define environment-specific variables for Terraform. We came to the conclusion to use terraform tfvars files instead of the maps. This change is needed to support that.