### PR TITLE
Enable terraform apply autoapprove in bluegreen deplyos

### DIFF
--- a/bluegreen.py
+++ b/bluegreen.py
@@ -89,7 +89,7 @@ def main(argv):
     # Retrieve autoscaling groups information (we need to do this again because the launchconig has changed and we need this in a later phase)
     info = getAutoscalingInfo(agBlue, agGreen)
 
-    if command == 'apply':
+    if 'apply' in command:
         print 'Waiting for 30 seconds to get autoscaling status'
         time.sleep(30)
         timeout = 30

--- a/deploy-bluegreen.yml
+++ b/deploy-bluegreen.yml
@@ -45,4 +45,4 @@ run:
     terraform init
     terraform workspace select $TF_ENVIRONMENT
     # Deploy
-    $WORKDIR/terraform-bluegreen/bluegreen.py -f $WORKDIR/terraform-repo/$TF_PROJECT_FOLDER -a $AMI_ID -c apply -t 500 -e $WORKDIR/terraform-repo/$TF_PROJECT_FOLDER/$TF_ENVIRONMENT.tfvars
+    $WORKDIR/terraform-bluegreen/bluegreen.py -f $WORKDIR/terraform-repo/$TF_PROJECT_FOLDER -a $AMI_ID -c "apply -auto-approve" -t 500 -e $WORKDIR/terraform-repo/$TF_PROJECT_FOLDER/$TF_ENVIRONMENT.tfvars


### PR DESCRIPTION
Since terraform version 0.11.0, terraform apply without plan needs interactive approval, this breaks the bluegreen deploys on concourse, so `-auto-approve` is added to avoid that

Find more details here:
https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#0110-november-16-2017