### PR TITLE
Make sure there is user_data so newer aws providers don't complain

### DIFF
--- a/blue-green/variables.tf
+++ b/blue-green/variables.tf
@@ -51,7 +51,7 @@ variable "associate_public_ip_address" {
 
 variable "user_data" {
   description = "(Optional) The user data to provide when launching the instance"
-  default     = ""
+  default     = "# Hello World"
 }
 
 variable "disk_volume_size" {

--- a/single-stack/variables.tf
+++ b/single-stack/variables.tf
@@ -51,7 +51,7 @@ variable "associate_public_ip_address" {
 
 variable "user_data" {
   description = "(Optional) The user data to provide when launching the instance"
-  default     = ""
+  default     = "# Hello World"
 }
 
 variable "disk_volume_size" {


### PR DESCRIPTION
Starting from aws provider 1.14, we're getting the following terraform error when specifying empty user_data:
```
Error: module.api.module.blue.aws_launch_configuration.bluegreen_launchconfig: expected length of user_data to be in the range (1 - 16384), got 
```

This PR makes sure there's a default value :)

Resources:
- https://github.com/terraform-providers/terraform-provider-aws/pull/2973
- https://github.com/terraform-providers/terraform-provider-aws/issues/4081