### PR TITLE
moves cpu-specific autoscaling to a more general autoscaling approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,34 @@ module "bluegreen" {
 }
 ```
 
-## cpu-scaling
+## scaling
 Terraform module to setup alarms and autoscaling triggers for autoscaling
 
 ### Variables
 
-See the [cpu-scaling/variables.tf](cpu-scaling/variables.tf) file.
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| adjustment\_down | The number of instances to remove when the alarm is triggered (the value has to be negative) | string | `"-1"` | no |
+| adjustment\_type | What typ of adjustment needs to happen | string | `"ChangeInCapacity"` | no |
+| adjustment\_up | The number of instances to add when the alarm is triggered | string | `"1"` | no |
+| autoscaling\_group\_name | The name of the AS group this config needs to be applied | list | n/a | yes |
+| cooldown\_down | The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start. | string | `"600"` | no |
+| cooldown\_up | The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start. | string | `"300"` | no |
+| dimension\_name |  | string | `"AutoScalingGroupName"` | no |
+| dimension\_value |  | string | `"false"` | no |
+| environment | Environment to deploy on | string | n/a | yes |
+| evaluation\_periods | the number of samples to evaluate | string | `"4"` | no |
+| metric\_name | The metric the scaling is based upon | string | `"CPUUtilization"` | no |
+| name | Name of the stack | string | n/a | yes |
+| namespace | the namespace of the cloudwatch metric | string | `"AWS/EC2"` | no |
+| num\_asg | the number of autoscaling groups passed | string | `"2"` | no |
+| period\_down | he period in seconds over which the selected metric statistic is applied. | string | `"120"` | no |
+| period\_up | he period in seconds over which the selected metric statistic is applied. | string | `"60"` | no |
+| policy\_type | The policy type, either SimpleScaling or StepScaling | string | `"SimpleScaling"` | no |
+| project | Project name to use | string | n/a | yes |
+| statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: | string | `"Average"` | no |
+| threshold\_down | The metric value to scale down | string | `"30"` | no |
+| threshold\_up | The metric value to scale up | string | `"80"` | no |
 
 ### Outputs
 /
@@ -47,8 +69,8 @@ See the [cpu-scaling/variables.tf](cpu-scaling/variables.tf) file.
 ### Example
 
 ```
-module "cpu-scaling" {
-  source = "github.com/skyscrapers/terraform-bluegreen//cpu-scaling"
+module "scaling" {
+  source = "github.com/skyscrapers/terraform-bluegreen//scaling"
   project = "example"
   name = "app"
   environment = "production"

--- a/scaling/main.tf
+++ b/scaling/main.tf
@@ -1,6 +1,6 @@
-resource "aws_cloudwatch_metric_alarm" "alarm-cpu-down" {
+resource "aws_cloudwatch_metric_alarm" "alarm_down" {
   count               = "${var.num_asg}"
-  alarm_name          = "${var.environment}-${var.project}-${var.name}-cpu-down${count.index}"
+  alarm_name          = "${var.environment}-${var.project}-${var.name}-down${count.index}"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "${var.evaluation_periods}"
   metric_name         = "${var.metric_name}"
@@ -11,12 +11,12 @@ resource "aws_cloudwatch_metric_alarm" "alarm-cpu-down" {
   dimensions          = "${map(var.dimension_name, var.dimension_value == "false" ? var.autoscaling_group_name[count.index] : var.dimension_value)}"
 
   alarm_description = "This metric monitors CPU utilization down"
-  alarm_actions     = ["${aws_autoscaling_policy.down-cpu.*.arn}"]
+  alarm_actions     = ["${aws_autoscaling_policy.down.*.arn}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "alarm-cpu-up" {
+resource "aws_cloudwatch_metric_alarm" "alarm_up" {
   count               = "${var.num_asg}"
-  alarm_name          = "${var.environment}-${var.project}-${var.name}-cpu-up${count.index}"
+  alarm_name          = "${var.environment}-${var.project}-${var.name}-up${count.index}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.evaluation_periods}"
   metric_name         = "${var.metric_name}"
@@ -27,12 +27,12 @@ resource "aws_cloudwatch_metric_alarm" "alarm-cpu-up" {
   dimensions          = "${map(var.dimension_name, var.dimension_value == "false" ? var.autoscaling_group_name[count.index] : var.dimension_value)}"
 
   alarm_description = "This metric monitors CPU utilization up"
-  alarm_actions     = ["${aws_autoscaling_policy.up-cpu.*.arn}"]
+  alarm_actions     = ["${aws_autoscaling_policy.up.*.arn}"]
 }
 
-resource "aws_autoscaling_policy" "up-cpu" {
+resource "aws_autoscaling_policy" "up" {
   count                  = "${var.num_asg}"
-  name                   = "${var.environment}-${var.project}-${var.name}-cpu-up${count.index}"
+  name                   = "${var.environment}-${var.project}-${var.name}-up${count.index}"
   autoscaling_group_name = "${var.autoscaling_group_name[count.index]}"
   adjustment_type        = "${var.adjustment_type}"
   policy_type            = "${var.policy_type}"
@@ -40,9 +40,9 @@ resource "aws_autoscaling_policy" "up-cpu" {
   scaling_adjustment     = "${var.adjustment_up}"
 }
 
-resource "aws_autoscaling_policy" "down-cpu" {
+resource "aws_autoscaling_policy" "down" {
   count                  = "${var.num_asg}"
-  name                   = "${var.environment}-${var.project}-${var.name}-cpu-down${count.index}"
+  name                   = "${var.environment}-${var.project}-${var.name}-down${count.index}"
   autoscaling_group_name = "${var.autoscaling_group_name[count.index]}"
   adjustment_type        = "${var.adjustment_type}"
   policy_type            = "${var.policy_type}"

--- a/scaling/variables.tf
+++ b/scaling/variables.tf
@@ -5,17 +5,17 @@ variable "evaluation_periods" {
 
 variable "namespace" {
   default     = "AWS/EC2"
-  description = "the namespace of the cpu cloudwatch metric"
+  description = "the namespace of the cloudwatch metric"
 }
 
 variable "period_down" {
   default     = "120"
-  description = "he period in seconds over which the CPUUtilization statistic is applied."
+  description = "he period in seconds over which the selected metric statistic is applied."
 }
 
 variable "period_up" {
   default     = "60"
-  description = "he period in seconds over which the CPUUtilization statistic is applied."
+  description = "he period in seconds over which the selected metric statistic is applied."
 }
 
 variable "statistic" {
@@ -25,12 +25,12 @@ variable "statistic" {
 
 variable "threshold_up" {
   default     = "80"
-  description = "The cpu value to scale up"
+  description = "The metric value to scale up"
 }
 
 variable "threshold_down" {
   default     = "30"
-  description = "The cpu value to scale down"
+  description = "The metric value to scale down"
 }
 
 variable "policy_type" {


### PR DESCRIPTION
This PR refactors the scaling policy. Just to notice, the module was already ready for a generic autoscaling approach but the naming was reflecting a cpu-specific scaling