### PR TITLE
Allow specifying spot_price

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,50 @@
 # terraform-bluegreen
 Terraform module to setup blue / green deployments
 
-##blue-green
+## blue-green
 
-### Variables
+### Inputs
 
-See the [blue-green/variables.tf](blue-green/variables.tf) file.
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| associate\_public\_ip\_address | (Optional) Associate a public ip address with an instance in a VPC | string | `"false"` | no |
+| blue\_ami | (Required) The EC2 image ID to launch in the blue autoscaling group | string | n/a | yes |
+| blue\_desired\_capacity | (Required) The number of Amazon EC2 instances that should be running in the blue autoscaling roup | string | n/a | yes |
+| blue\_max\_size | (Required) The maximum size of the blue autoscaling group | string | n/a | yes |
+| blue\_min\_size | (Required) The minimum size of the blue autoscaling group | string | n/a | yes |
+| disk\_volume\_size | (Optional) The size of the volume in gigabytes | string | `"8"` | no |
+| disk\_volume\_type | (Optional) The type of the volume. Default is standard | string | `"standard"` | no |
+| environment | Environment to deploy on | string | n/a | yes |
+| green\_ami | (Required) The EC2 image ID to launch in the green autoscaling group | string | n/a | yes |
+| green\_desired\_capacity | (Required) The number of Amazon EC2 instances that should be running in the green autoscaling roup | string | n/a | yes |
+| green\_max\_size | (Required) The maximum size of the green autoscaling group | string | n/a | yes |
+| green\_min\_size | (Required) The minimum size of the green autoscaling group | string | n/a | yes |
+| health\_check\_grace\_period | (Optional, Default: 300) Time (in seconds) after instance comes into service before checking health | string | `"300"` | no |
+| health\_check\_type | The health check type to apply to the Autoscaling groups. | string | `"ELB"` | no |
+| iam\_instance\_profile | (Optional) The IAM instance profile to associate with launched instances | string | `""` | no |
+| instance\_type | (Required) The size of instance to launch | string | n/a | yes |
+| key\_name | (Optional) The key name that should be used for the instance | string | `""` | no |
+| loadbalancers | (Optional) A list of load balancer names to add to the autoscaling groups | list | `<list>` | no |
+| name | Name of the stack | string | n/a | yes |
+| project | Project name to use | string | n/a | yes |
+| security\_groups | (Optional) A list of associated security group IDS | list | `<list>` | no |
+| spot\_price | Spot price you want to pay for your instances. By default this is empty and we will use on-demand instances | string | `""` | no |
+| subnets | (Optional) A list of subnet IDs to launch resources in | list | `<list>` | no |
+| tags | (Optional, Default: []) List of map of additional tags | list | `<list>` | no |
+| target\_group\_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
+| termination\_policies | (Optional, Default: ['Default']) Order in termination policies to apply when choosing instances to terminate. | list | `<list>` | no |
+| user\_data | (Optional) The user data to provide when launching the instance | string | `"# Hello World"` | no |
 
 ### Outputs
 
-* `blue_asg_id`: (Number) blue autoscaling group id
-* `green_asg_id`: (Number) green autoscaling group id
+| Name | Description |
+|------|-------------|
+| blue\_asg\_id |  |
+| green\_asg\_id |  |
 
 ### Example
 
-```
+```terraform
 module "bluegreen" {
   source = "github.com/skyscrapers/terraform-bluegreen//blue-green"
   project = "example"
@@ -35,9 +65,10 @@ module "bluegreen" {
 ```
 
 ## scaling
+
 Terraform module to setup alarms and autoscaling triggers for autoscaling
 
-### Variables
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
@@ -63,12 +94,9 @@ Terraform module to setup alarms and autoscaling triggers for autoscaling
 | threshold\_down | The metric value to scale down | string | `"30"` | no |
 | threshold\_up | The metric value to scale up | string | `"80"` | no |
 
-### Outputs
-/
-
 ### Example
 
-```
+```terraform
 module "scaling" {
   source = "github.com/skyscrapers/terraform-bluegreen//scaling"
   project = "example"
@@ -83,8 +111,9 @@ module "scaling" {
 The `bluegreen.py` script performs a bluegreen deployment of the selected terraform stack. It only works with Python 2.7.
 The blue-green deployment script expects certain inputs and outputs in the Terraform project you want to deploy in a blue-green fashion.
 
-### Required outputs:
-```
+### Required outputs
+
+```terraform
 output "blue_asg_id" {
   value = "${module.<blue-green-module-name>.blue_asg_id}"
 }
@@ -93,8 +122,10 @@ output "green_asg_id" {
   value = "${module.<blue-green-module-name>.green_asg_id}"
 }
 ```
-### Required variables:
-```
+
+### Required variables
+
+```terraform
 variable "blue_max_size" {
   description = "max instances blue"
 }

--- a/blue-green/main.tf
+++ b/blue-green/main.tf
@@ -1,11 +1,11 @@
 module "blue" {
-  source           = "../single-stack"
-  color            = "blue"
-  max_size         = "${var.blue_max_size}"
-  min_size         = "${var.blue_min_size}"
-  desired_capacity = "${var.blue_desired_capacity}"
-  ami              = "${var.blue_ami}"
-
+  source                      = "../single-stack"
+  color                       = "blue"
+  max_size                    = "${var.blue_max_size}"
+  min_size                    = "${var.blue_min_size}"
+  desired_capacity            = "${var.blue_desired_capacity}"
+  ami                         = "${var.blue_ami}"
+  spot_price                  = "${var.spot_price}"
   loadbalancers               = "${var.loadbalancers}"
   project                     = "${var.project}"
   name                        = "${var.name}"
@@ -27,13 +27,13 @@ module "blue" {
 }
 
 module "green" {
-  source           = "../single-stack"
-  color            = "green"
-  max_size         = "${var.green_max_size}"
-  min_size         = "${var.green_min_size}"
-  desired_capacity = "${var.green_desired_capacity}"
-  ami              = "${var.green_ami}"
-
+  source                      = "../single-stack"
+  color                       = "green"
+  max_size                    = "${var.green_max_size}"
+  min_size                    = "${var.green_min_size}"
+  desired_capacity            = "${var.green_desired_capacity}"
+  ami                         = "${var.green_ami}"
+  spot_price                  = "${var.spot_price}"
   loadbalancers               = "${var.loadbalancers}"
   project                     = "${var.project}"
   name                        = "${var.name}"

--- a/blue-green/variables.tf
+++ b/blue-green/variables.tf
@@ -121,3 +121,8 @@ variable "tags" {
   type        = "list"
   default     = []
 }
+
+variable "spot_price" {
+  description = "Spot price you want to pay for your instances. By default this is empty and we will use on-demand instances"
+  default     = ""
+}

--- a/single-stack/main.tf
+++ b/single-stack/main.tf
@@ -6,6 +6,7 @@ resource "aws_launch_configuration" "bluegreen_launchconfig" {
   iam_instance_profile        = "${var.iam_instance_profile}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
   user_data                   = "${var.user_data}"
+  spot_price                  = "${var.spot_price}"
 
   root_block_device {
     volume_type           = "${var.disk_volume_type}"

--- a/single-stack/variables.tf
+++ b/single-stack/variables.tf
@@ -109,3 +109,8 @@ variable "tags" {
   type        = "list"
   default     = []
 }
+
+variable "spot_price" {
+  description = "Spot price you want to pay for your instances. By default this is empty and we will use on-demand instances"
+  default     = ""
+}


### PR DESCRIPTION
- Allows for specifying a spot instance price
- Fixes / updates documentation

Needed to bring our EKS solution on par with our kops setups feature-wise. Related issue: https://github.com/skyscrapers/engineering/issues/218

Tested with the EKS solution

**Note**: This is a small change to make spot instances work currently. However we will eventually migrate to using the newer `aws_launch_template` instead, so we can have more options, like mixed on-demand/spot etc. This will be covered in: https://github.com/skyscrapers/engineering/issues/202