### PR TITLE
adds option to specify wait_for_capacity_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Terraform module to setup blue / green deployments
 | target\_group\_arns | A list of aws_alb_target_group ARNs, for use with Application Load Balancing | list | `<list>` | no |
 | termination\_policies | (Optional, Default: ['Default']) Order in termination policies to apply when choosing instances to terminate. | list | `<list>` | no |
 | user\_data | (Optional) The user data to provide when launching the instance | string | `"# Hello World"` | no |
+| wait\_for\_capacity\_timeout | A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to 0 causes Terraform to skip all Capacity Waiting behavior. | string | `"10m"` | no |
 
 ### Outputs
 
 | Name | Description |
 |------|-------------|
-| blue\_asg\_id |  |
-| green\_asg\_id |  |
+| blue\_asg\_id | Blue autoscaling group id |
+| green\_asg\_id | Green autoscaling group id |
 
 ### Example
 

--- a/blue-green/main.tf
+++ b/blue-green/main.tf
@@ -24,6 +24,7 @@ module "blue" {
   target_group_arns           = "${var.target_group_arns}"
   health_check_type           = "${var.health_check_type}"
   tags                        = "${var.tags}"
+  wait_for_capacity_timeout   = "${var.wait_for_capacity_timeout}"
 }
 
 module "green" {
@@ -52,4 +53,5 @@ module "green" {
   target_group_arns           = "${var.target_group_arns}"
   health_check_type           = "${var.health_check_type}"
   tags                        = "${var.tags}"
+  wait_for_capacity_timeout   = "${var.wait_for_capacity_timeout}"
 }

--- a/blue-green/outputs.tf
+++ b/blue-green/outputs.tf
@@ -1,7 +1,9 @@
 output "blue_asg_id" {
+  description = "Blue autoscaling group id"
   value = "${module.blue.asg_id}"
 }
 
 output "green_asg_id" {
+  description = "Green autoscaling group id"
   value = "${module.green.asg_id}"
 }

--- a/blue-green/variables.tf
+++ b/blue-green/variables.tf
@@ -126,3 +126,8 @@ variable "spot_price" {
   description = "Spot price you want to pay for your instances. By default this is empty and we will use on-demand instances"
   default     = ""
 }
+
+variable "wait_for_capacity_timeout" {
+  description = " A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to 0 causes Terraform to skip all Capacity Waiting behavior."
+  default     = "10m"
+}

--- a/single-stack/main.tf
+++ b/single-stack/main.tf
@@ -31,7 +31,8 @@ resource "aws_autoscaling_group" "bluegreen_asg" {
   health_check_grace_period = "${var.health_check_grace_period}"
   termination_policies      = ["${var.termination_policies}"]
   target_group_arns         = ["${var.target_group_arns}"]
-
+  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
+  
   tags = ["${concat(
   list(
     map("key", "Environment", "value", "${var.environment}", "propagate_at_launch", true),

--- a/single-stack/variables.tf
+++ b/single-stack/variables.tf
@@ -114,3 +114,8 @@ variable "spot_price" {
   description = "Spot price you want to pay for your instances. By default this is empty and we will use on-demand instances"
   default     = ""
 }
+
+variable "wait_for_capacity_timeout" {
+  description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to 0 causes Terraform to skip all Capacity Waiting behavior."
+  default     = "10m"
+}


### PR DESCRIPTION
Tested with a plan in customer stack.

This option allows to set the maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to 0 causes Terraform to skip all Capacity Waiting behavior.