### PR TITLE
fix bug in scaling module 

### DIFF
--- a/scaling/main.tf
+++ b/scaling/main.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_down" {
   threshold           = var.threshold_down
 
   dimensions = {
-    var.dimension_name = coalesce(var.dimension_value, var.autoscaling_group_names[count.index])
+    "${var.dimension_name}" = coalesce(var.dimension_value, var.autoscaling_group_names[count.index])
   }
 
   alarm_description = "This metric monitors CPU utilization down"
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm_up" {
   threshold           = var.threshold_up
 
   dimensions = {
-    var.dimension_name = coalesce(var.dimension_value, var.autoscaling_group_names[count.index])
+    "${var.dimension_name}" = coalesce(var.dimension_value, var.autoscaling_group_names[count.index])
   }
 
   alarm_description = "This metric monitors CPU utilization up"


### PR DESCRIPTION
after upgrade to tf 0.12 we encountered the following error:
```
Error: Ambiguous attribute key

  on .terraform/modules/cpu-scaling/scaling/main.tf line 13, in resource "aws_cloudwatch_metric_alarm" "alarm_down":
  13:     var.dimension_name = coalesce(var.dimension_value, var.autoscaling_group_names[count.index])
If this expression is intended to be a reference, wrap it in parentheses. If
it's instead intended as a literal name containing periods, wrap it in quotes
to create a string literal
```
 Created a fix as per https://github.com/hashicorp/terraform/issues/21566